### PR TITLE
More expanded variables (1.16.5)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ processResources {
 // this fixes some edge cases with special characters not displaying correctly
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
 compileJava {
-	options.encoding = "UTF-8"
+	options.encoding = 'UTF-8'
 }
 
 java {

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = sourceCompatibility
+compileKotlin.kotlinOptions.jvmTarget = '1.8'
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -38,35 +39,32 @@ dependencies {
 }
 
 processResources {
-	inputs.property 'version', project.version
-
-	from(sourceSets.main.resources.srcDirs) {
-		include 'fabric.mod.json'
-		expand 'version': project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude 'fabric.mod.json'
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version,
+			"loader_version": project.loader_version,
+			"fabric_kotlin_version": project.fabric_kotlin_version,
+			"mc_version": project.minecraft_version
 	}
 }
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is
 // this fixes some edge cases with special characters not displaying correctly
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+compileJava {
+	options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-	archiveClassifier.set('sources')
-	from sourceSets.main.allSource
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
 }
 
 jar {
-	from 'LICENSE'
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}" }
+	}
 }
 
 // configure the maven publication
@@ -94,5 +92,3 @@ publishing {
 		}
 	}
 }
-
-compileKotlin.kotlinOptions.jvmTarget = '1.8'

--- a/build.gradle
+++ b/build.gradle
@@ -44,10 +44,10 @@ processResources {
 			"loader_version": project.loader_version,
 			"fabric_kotlin_version": project.fabric_kotlin_version,
 			"mc_version": project.minecraft_version,
-			"mod_id": project.mod_id,
 			"mod_name": project.mod_name,
 			"github_url": project.github_url,
-			"icon_path": project.icon_path
+			"icon_path": project.icon_path,
+			"archives_base_name": project.archives_base_name
 	}
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,11 @@ processResources {
 		expand "version": project.version,
 			"loader_version": project.loader_version,
 			"fabric_kotlin_version": project.fabric_kotlin_version,
-			"mc_version": project.minecraft_version
+			"mc_version": project.minecraft_version,
+			"mod_id": project.mod_id,
+			"mod_name": project.mod_name,
+			"github_url": project.github_url,
+			"icon_path": project.icon_path
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,10 @@ loom_version = 0.7-SNAPSHOT
 mod_version = 1.0.0
 maven_group = net.logandark
 archives_base_name = barebones
+mod_id = barebones
+mod_name = Barebones
+github_url = https://github.com/LoganDark/fabric-barebones
+icon_path = assets/barebones/icon.png
 
 # Kotlin
 kotlin_version = 1.5.31

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,7 +16,6 @@ loom_version = 0.7-SNAPSHOT
 mod_version = 1.0.0
 maven_group = net.logandark
 archives_base_name = barebones
-mod_id = barebones
 mod_name = Barebones
 github_url = https://github.com/LoganDark/fabric-barebones
 icon_path = assets/barebones/icon.png

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,14 @@ org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 # Check these on https://modmuss50.me/fabric.html
-minecraft_version = 1.16.3
-yarn_mappings = 1.16.3+build.11
+minecraft_version = 1.16.5
+yarn_mappings = 1.16.5+build.10
 loader_version = 0.9.3+build.207
 
 #Fabric api
-fabric_version = 0.21.0+build.407-1.16
-loom_version = 0.5-SNAPSHOT
+fabric_version = 0.41.3+1.16
+#Last loom version that does not require java 16
+loom_version = 0.7-SNAPSHOT
 
 # Mod Properties
 mod_version = 1.0.0
@@ -17,5 +18,5 @@ maven_group = net.logandark
 archives_base_name = barebones
 
 # Kotlin
-kotlin_version = 1.3.71
-fabric_kotlin_version = 1.3.71+build.1
+kotlin_version = 1.5.31
+fabric_kotlin_version = 1.6.5+kotlin.1.5.31

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Jul 27 10:29:07 IDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/run/options.txt
+++ b/run/options.txt
@@ -1,4 +1,4 @@
-version:2580
+version:2586
 autoJump:false
 autoSuggestions:true
 chatColors:true
@@ -63,6 +63,8 @@ mouseWheelSensitivity:1.0
 rawMouseInput:true
 glDebugVerbosity:1
 skipMultiplayerWarning:true
+hideMatchedNames:true
+joinedFirstServer:false
 syncChunkWrites:false
 key_key.attack:key.mouse.left
 key_key.use:key.mouse.right
@@ -79,6 +81,7 @@ key_key.chat:key.keyboard.t
 key_key.playerlist:key.keyboard.tab
 key_key.pickItem:key.keyboard.p
 key_key.command:key.keyboard.slash
+key_key.socialInteractions:key.keyboard.p
 key_key.screenshot:key.keyboard.f2
 key_key.togglePerspective:key.keyboard.f5
 key_key.smoothCamera:key.keyboard.f8

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
 	repositories {
-		jcenter()
 		maven {
 			name = 'Fabric'
 			url = 'https://maven.fabricmc.net/'

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,21 +1,21 @@
 {
 	"schemaVersion": 1,
-	"id": "barebones",
+	"id": "${mod_id}",
 	"version": "${version}",
 
 	"name": "Barebones",
 	"description": "Congrats, you made it work!",
 	"authors": ["LoganDark"],
 	"contact": {
-		"sources": "https://github.com/LoganDark/fabric-barebones",
-		"website": "https://github.com/LoganDark/fabric-barebones",
-		"issues": "https://github.com/LoganDark/fabric-barebones/issues"
+		"sources": "${github_url}",
+		"website": "${github_url}",
+		"issues": "${github_url}/issues"
 	},
 
 	"custom": {},
 
 	"license": "GPLv3",
-	"icon": "assets/barebones/icon.png",
+	"icon": "${icon_path}",
 
 	"environment": "*",
 	"entrypoints": {

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
 	"schemaVersion": 1,
-	"id": "${mod_id}",
+	"id": "${archives_base_name}",
 	"version": "${version}",
 
 	"name": "Barebones",

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
 	"mixins": ["barebones.mixins.json"],
 
 	"depends": {
-		"fabricloader": ">=0.8.8",
-		"fabric-language-kotlin": ">=1.3.71+build.1",
-		"minecraft": "1.16.x"
+		"fabricloader": ">=${loader_version}",
+		"fabric-language-kotlin": ">=${fabric_kotlin_version}",
+		"minecraft": "${mc_version}"
 	},
 	"suggests": {}
 }


### PR DESCRIPTION
Added even more expanded variables in 7b61178676d86e92cff7a1cda151d5bd3f0949d0 because it might come in handy:
- mod_id = barebones
- mod_name = Barebones
- github_url = `https://github.com/LoganDark/fabric-barebones`
- icon_path = `assets/barebones/icon.png`

This PR uses all dependency updates from LoganDark/fabric-barebones/pull/3 to avoid future merges with 1.16.5 and 1.17.1.