### PR TITLE
1.16.5 dependency updates from approved changes on LoganDark/fabric-console/pull/6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,8 @@ plugins {
 }
 
 sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = sourceCompatibility
+compileKotlin.kotlinOptions.jvmTarget = '1.8'
 
 archivesBaseName = project.archives_base_name
 version = project.mod_version
@@ -38,35 +39,32 @@ dependencies {
 }
 
 processResources {
-	inputs.property 'version', project.version
-
-	from(sourceSets.main.resources.srcDirs) {
-		include 'fabric.mod.json'
-		expand 'version': project.version
-	}
-
-	from(sourceSets.main.resources.srcDirs) {
-		exclude 'fabric.mod.json'
+	filesMatching("fabric.mod.json") {
+		expand "version": project.version,
+			"loader_version": project.loader_version,
+			"fabric_kotlin_version": project.fabric_kotlin_version,
+			"mc_version": project.minecraft_version
 	}
 }
 
 // ensure that the encoding is set to UTF-8, no matter what the system default is
 // this fixes some edge cases with special characters not displaying correctly
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-tasks.withType(JavaCompile) {
-	options.encoding = 'UTF-8'
+compileJava {
+	options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
-task sourcesJar(type: Jar, dependsOn: classes) {
-	archiveClassifier.set('sources')
-	from sourceSets.main.allSource
+java {
+	// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
+	// if it is present.
+	// If you remove this line, sources will not be generated.
+	withSourcesJar()
 }
 
 jar {
-	from 'LICENSE'
+	from("LICENSE") {
+		rename { "${it}_${project.archivesBaseName}" }
+	}
 }
 
 // configure the maven publication
@@ -94,5 +92,3 @@ publishing {
 		}
 	}
 }
-
-compileKotlin.kotlinOptions.jvmTarget = '1.8'

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,13 +3,14 @@ org.gradle.jvmargs = -Xmx1G
 
 # Fabric Properties
 # Check these on https://modmuss50.me/fabric.html
-minecraft_version = 1.16.3
-yarn_mappings = 1.16.3+build.11
+minecraft_version = 1.16.5
+yarn_mappings = 1.16.5+build.10
 loader_version = 0.9.3+build.207
 
 #Fabric api
-fabric_version = 0.21.0+build.407-1.16
-loom_version = 0.5-SNAPSHOT
+fabric_version = 0.41.3+1.16
+#Last loom version that does not require java 16
+loom_version = 0.7-SNAPSHOT
 
 # Mod Properties
 mod_version = 1.0.0
@@ -17,5 +18,5 @@ maven_group = net.logandark
 archives_base_name = barebones
 
 # Kotlin
-kotlin_version = 1.3.71
-fabric_kotlin_version = 1.3.71+build.1
+kotlin_version = 1.5.31
+fabric_kotlin_version = 1.6.5+kotlin.1.5.31

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 #Sat Jul 27 10:29:07 IDT 2019
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.1-all.zip
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
 	repositories {
-		jcenter()
 		maven {
 			name = 'Fabric'
 			url = 'https://maven.fabricmc.net/'

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,9 +30,9 @@
 	"mixins": ["barebones.mixins.json"],
 
 	"depends": {
-		"fabricloader": ">=0.8.8",
-		"fabric-language-kotlin": ">=1.3.71+build.1",
-		"minecraft": "1.16.x"
+		"fabricloader": ">=${loader_version}",
+		"fabric-language-kotlin": ">=${fabric_kotlin_version}",
+		"minecraft": "${mc_version}"
 	},
 	"suggests": {}
 }


### PR DESCRIPTION
Added currently approved changes in c2e89a32737a24811ab653096933332e371f279d from LoganDark/fabric-console/pull/6:
- Removed .idea/ from remote repository;
- Updated dependencies to mc 1.16.5;
- Updated Gradle to 6.9.1 (last Gradle version that does not require Java 16);
- Added more expanded variables on fabric.mod.json.